### PR TITLE
GPS Plugin: ROS2 Service for Activation & Spoofing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ option(SEND_ODOMETRY_DATA "Send Mavlink ODOMETRY msgs" OFF)
 find_package(Boost 1.58 REQUIRED COMPONENTS system thread filesystem)
 find_package(gazebo REQUIRED)
 find_package(PkgConfig REQUIRED)
+find_package(gazebo_ros REQUIRED)
+find_package(std_srvs REQUIRED)
 pkg_search_module(GLIB REQUIRED glib-2.0)
 # Note: If using catkin, Python 2 is found since it points
 # to the Python libs installed with the ROS distro

--- a/include/gazebo_gps_plugin.h
+++ b/include/gazebo_gps_plugin.h
@@ -24,17 +24,17 @@
  * @author Nuno Marques <nuno.marques@dronesolutions.io>
  */
 
-#ifndef _GAZEBO_GPS_PLUGIN_HH_
-#define _GAZEBO_GPS_PLUGIN_HH_
+#ifndef _GAZEBO_ROS_GPS_PLUGIN_HH_
+#define _GAZEBO_ROS_GPS_PLUGIN_HH_
 
 #include <math.h>
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
 #include <queue>
 #include <random>
 
 #include <sdf/sdf.hh>
-#include <common.h>
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/gazebo.hh>
@@ -47,23 +47,27 @@
 #include <gazebo/sensors/SensorTypes.hh>
 #include <gazebo/sensors/GpsSensor.hh>
 
+#include <gazebo_ros/node.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_srvs/srv/set_bool.hpp>
+
+#include <common.h>
 #include <SITLGps.pb.h>
 
 namespace gazebo
 {
-static constexpr double kDefaultUpdateRate = 5.0;               // hz
-static constexpr double kDefaultGpsXYRandomWalk = 2.0;          // (m/s) / sqrt(hz)
-static constexpr double kDefaultGpsZRandomWalk = 4.0;           // (m/s) / sqrt(hz)
-static constexpr double kDefaultGpsXYNoiseDensity = 2.0e-4;     // (m) / sqrt(hz)
-static constexpr double kDefaultGpsZNoiseDensity = 4.0e-4;      // (m) / sqrt(hz)
-static constexpr double kDefaultGpsVXYNoiseDensity = 0.2;       // (m/s) / sqrt(hz)
-static constexpr double kDefaultGpsVZNoiseDensity = 0.4;        // (m/s) / sqrt(hz)
+static constexpr double kDefaultUpdateRate         = 5.0;     // hz
+static constexpr double kDefaultGpsXYRandomWalk    = 2.0;     // (m/s) / sqrt(hz)
+static constexpr double kDefaultGpsZRandomWalk     = 4.0;     // (m/s) / sqrt(hz)
+static constexpr double kDefaultGpsXYNoiseDensity  = 2.0e-4;  // (m) / sqrt(hz)
+static constexpr double kDefaultGpsZNoiseDensity   = 4.0e-4;  // (m) / sqrt(hz)
+static constexpr double kDefaultGpsVXYNoiseDensity = 0.2;     // (m/s) / sqrt(hz)
+static constexpr double kDefaultGpsVZNoiseDensity  = 0.4;     // (m/s) / sqrt(hz)
 
-class GAZEBO_VISIBLE GpsPlugin : public SensorPlugin
-{
+class GAZEBO_VISIBLE GazeboRosGpsPlugin : public SensorPlugin {
 public:
-  GpsPlugin();
-  virtual ~GpsPlugin();
+  GazeboRosGpsPlugin();
+  virtual ~GazeboRosGpsPlugin();
 
 protected:
   virtual void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
@@ -71,50 +75,72 @@ protected:
   virtual void OnWorldUpdate(const common::UpdateInfo& /*_info*/);
 
 private:
-  std::string namespace_;
-  std::string gps_id_;
-  std::default_random_engine random_generator_;
+  bool active_ = true;
+  bool bad_gps_ = false;
+  bool spoofing_active_ = false;
+  bool activationCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request, std::shared_ptr<std_srvs::srv::SetBool::Response> response);
+  bool setBadGpsCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request, std::shared_ptr<std_srvs::srv::SetBool::Response> response);
+  bool activationGPSSpoofing(const std::shared_ptr<std_srvs::srv::SetBool::Request> request, std::shared_ptr<std_srvs::srv::SetBool::Response> response);
+
+  std::string                     namespace_;
+  std::string                     gps_id_;
+  std::default_random_engine      random_generator_;
   std::normal_distribution<float> standard_normal_distribution_;
 
   bool gps_noise_;
 
+  ignition::math::Vector3d pos_W_I{};
+  std::pair<double, double> latlon;
+
   std::string model_name_;
 
   sensors::GpsSensorPtr parentSensor_;
-  physics::ModelPtr model_;
-  physics::WorldPtr world_;
-  event::ConnectionPtr updateWorldConnection_;
-  event::ConnectionPtr updateSensorConnection_;
+  physics::ModelPtr     model_;
+  physics::WorldPtr     world_;
+  event::ConnectionPtr  updateWorldConnection_;
+  event::ConnectionPtr  updateSensorConnection_;
 
-  transport::NodePtr node_handle_;
+  transport::NodePtr      node_handle_;
   transport::PublisherPtr gps_pub_;
 
   std::string gps_topic_;
-  double update_rate_;
+  double      update_rate_;
 
   common::Time last_gps_time_;
   common::Time last_time_;
   common::Time current_time_;
   common::Time start_time_;
 
+  common::Time spoof_start_time;
+
   std::mutex data_mutex_;
+  std::mutex active_mutex_;
+  std::mutex set_bad_gps_mutex_;
+  std::mutex gps_spoof_mutex_;
+
+  gazebo_ros::Node::SharedPtr                      ros_node_;
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr activation_service_;
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_bad_gps_service_;
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr activation_spoof_service_;
 
   // Home defaults to Zurich Irchel Park
   // @note The home position can be specified using the environment variables:
   // PX4_HOME_LAT, PX4_HOME_LON, and PX4_HOME_ALT
-  double lat_home_ = kDefaultHomeLatitude;
-  double lon_home_ = kDefaultHomeLongitude;
-  double alt_home_ = kDefaultHomeAltitude;
-  double world_latitude_ = 0.0;
+  double lat_home_        = kDefaultHomeLatitude;
+  double lon_home_        = kDefaultHomeLongitude;
+  double alt_home_        = kDefaultHomeAltitude;
+  double world_latitude_  = 0.0;
   double world_longitude_ = 0.0;
-  double world_altitude_ = 0.0;
+  double world_altitude_  = 0.0;
 
   // gps delay related
-  static constexpr double gps_delay_ = 0.12;           // 120 ms
-  static constexpr int gps_buffer_size_max_ = 1000;
+  static constexpr double                gps_delay_           = 0.12;  // 120 ms
+  static constexpr int                   gps_buffer_size_max_ = 1000;
   std::queue<sensor_msgs::msgs::SITLGps> gps_delay_buffer_;
 
   ignition::math::Vector3d gps_bias_;
+  ignition::math::Vector3d gps_attack_{};
+  std::vector<ignition::math::Vector3d> gps_record_;
   ignition::math::Vector3d noise_gps_pos_;
   ignition::math::Vector3d noise_gps_vel_;
   ignition::math::Vector3d random_walk_gps_;
@@ -122,17 +148,17 @@ private:
   ignition::math::Vector3d velocity_prev_W_;
 
   // gps noise parameters
-  double std_xy_;    // meters
-  double std_z_;     // meters
-  std::default_random_engine rand_;
+  double                          std_xy_;  // meters
+  double                          std_z_;   // meters
+  std::default_random_engine      rand_;
   std::normal_distribution<float> randn_;
-  static constexpr const double gps_corellation_time_ = 60.0;    // s
-  double gps_xy_random_walk_;
-  double gps_z_random_walk_;
-  double gps_xy_noise_density_;
-  double gps_z_noise_density_;
-  double gps_vxy_noise_density_;
-  double gps_vz_noise_density_;
-};     // class GAZEBO_VISIBLE GpsPlugin
-}      // namespace gazebo
-#endif // _GAZEBO_GPS_PLUGIN_HH_
+  static constexpr const double   gps_corellation_time_ = 60.0;  // s
+  double                          gps_xy_random_walk_;
+  double                          gps_z_random_walk_;
+  double                          gps_xy_noise_density_;
+  double                          gps_z_noise_density_;
+  double                          gps_vxy_noise_density_;
+  double                          gps_vz_noise_density_;
+};  // class GAZEBO_VISIBLE GazeboRosGpsPlugin
+}  // namespace gazebo
+#endif  // _GAZEBO_ROS_GPS_PLUGIN_HH_

--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -27,39 +27,38 @@
 #include <gazebo_gps_plugin.h>
 
 #include <boost/algorithm/string.hpp>
+#include <memory>
+#include <rclcpp/utilities.hpp>
 
 using namespace std;
 
-namespace gazebo {
-GZ_REGISTER_SENSOR_PLUGIN(GpsPlugin)
-
-GpsPlugin::GpsPlugin() : SensorPlugin()
-{ }
-
-GpsPlugin::~GpsPlugin()
+namespace gazebo
 {
+GZ_REGISTER_SENSOR_PLUGIN(GazeboRosGpsPlugin)
+
+GazeboRosGpsPlugin::GazeboRosGpsPlugin() : SensorPlugin() {
+}
+
+GazeboRosGpsPlugin::~GazeboRosGpsPlugin() {
   if (updateSensorConnection_)
     updateSensorConnection_->~Connection();
   parentSensor_.reset();
   world_->Reset();
 }
 
-void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
-{
+void GazeboRosGpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf) {
   // Get then name of the parent sensor
   parentSensor_ = std::dynamic_pointer_cast<sensors::GpsSensor>(_parent);
 
   if (!parentSensor_)
-    gzthrow("GpsPlugin requires a GPS Sensor as its parent");
+    gzthrow("GazeboRosGpsPlugin requires a GPS Sensor as its parent");
 
   // Get the root model name
-  const string scopedName = _parent->ParentName();
+  const string        scopedName = _parent->ParentName();
   vector<std::string> names_splitted;
   boost::split(names_splitted, scopedName, boost::is_any_of("::"));
-  names_splitted.erase(std::remove_if(begin(names_splitted), end(names_splitted),
-                            [](const string& name)
-                            { return name.size() == 0; }), end(names_splitted));
-  const string rootModelName = names_splitted.front(); // The first element is the name of the root model
+  names_splitted.erase(std::remove_if(begin(names_splitted), end(names_splitted), [](const string& name) { return name.size() == 0; }), end(names_splitted));
+  const string rootModelName = names_splitted.front();  // The first element is the name of the root model
 
   // the second to the last name is the model name
   const string parentSensorModelName = names_splitted.rbegin()[1];
@@ -68,32 +67,32 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   model_name_ = names_splitted[0];
 
   // get gps topic name
-  if(_sdf->HasElement("topic")) {
+  if (_sdf->HasElement("topic")) {
     gps_topic_ = _sdf->GetElement("topic")->Get<std::string>();
   } else {
     // if not set by parameter, get the topic name from the model name
     gps_topic_ = parentSensorModelName;
-    gzwarn << "[gazebo_gps_plugin]: " + names_splitted.front() + "::" + names_splitted.rbegin()[1] +
-      " using gps topic \"" << parentSensorModelName << "\"\n";
+    gzwarn << "[gazebo_ros_gps_plugin]: " + names_splitted.front() + "::" + names_splitted.rbegin()[1] + " using gps topic \"" << parentSensorModelName
+           << "\"\n";
   }
 
   // Store the pointer to the world.
   world_ = physics::get_world(parentSensor_->WorldName());
 
-  #if GAZEBO_MAJOR_VERSION >= 9
-    last_time_ = world_->SimTime();
-    last_gps_time_ = world_->SimTime();
-    start_time_ = world_->StartTime();
-  #else
-    last_time_ = world_->GetSimTime();
-    last_gps_time_ = world_->GetSimTime();
-    start_time_ = world_->GetStartTime();
-  #endif
+#if GAZEBO_MAJOR_VERSION >= 9
+  last_time_     = world_->SimTime();
+  last_gps_time_ = world_->SimTime();
+  start_time_    = world_->StartTime();
+#else
+  last_time_     = world_->GetSimTime();
+  last_gps_time_ = world_->GetSimTime();
+  start_time_    = world_->GetStartTime();
+#endif
 
   // Use environment variables if set for home position.
-  const char *env_lat = std::getenv("PX4_HOME_LAT");
-  const char *env_lon = std::getenv("PX4_HOME_LON");
-  const char *env_alt = std::getenv("PX4_HOME_ALT");
+  const char* env_lat = std::getenv("PX4_HOME_LAT");
+  const char* env_lon = std::getenv("PX4_HOME_LON");
+  const char* env_alt = std::getenv("PX4_HOME_ALT");
 
   // Get noise param
   if (_sdf->HasElement("gpsNoise")) {
@@ -106,11 +105,11 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 
   if (env_lat) {
     lat_home_ = std::stod(env_lat) * M_PI / 180.0;
-    gzmsg << "[gazebo_gps_plugin] Home latitude is set to " << std::stod(env_lat) << ".\n";
+    gzmsg << "[gazebo_ros_gps_plugin] Home latitude is set to " << std::stod(env_lat) << ".\n";
   } else if (world_has_origin) {
     lat_home_ = world_latitude_;
-    gzmsg << "[gazebo_gps_plugin] Home latitude is set to " << lat_home_ << ".\n";
-  } else if(_sdf->HasElement("homeLatitude")) {
+    gzmsg << "[gazebo_ros_gps_plugin] Home latitude is set to " << lat_home_ << ".\n";
+  } else if (_sdf->HasElement("homeLatitude")) {
     double latitude;
     getSdfParam<double>(_sdf, "homeLatitude", latitude, lat_home_);
     lat_home_ = latitude * M_PI / 180.0;
@@ -118,11 +117,11 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 
   if (env_lon) {
     lon_home_ = std::stod(env_lon) * M_PI / 180.0;
-    gzmsg << "[gazebo_gps_plugin] Home longitude is set to " << std::stod(env_lon) << ".\n";
+    gzmsg << "[gazebo_ros_gps_plugin] Home longitude is set to " << std::stod(env_lon) << ".\n";
   } else if (world_has_origin) {
     lon_home_ = world_longitude_;
-    gzmsg << "[gazebo_gps_plugin] Home longitude is set to " << lon_home_ << ".\n";
-  } else if(_sdf->HasElement("homeLongitude")) {
+    gzmsg << "[gazebo_ros_gps_plugin] Home longitude is set to " << lon_home_ << ".\n";
+  } else if (_sdf->HasElement("homeLongitude")) {
     double longitude;
     getSdfParam<double>(_sdf, "homeLongitude", longitude, lon_home_);
     lon_home_ = longitude * M_PI / 180.0;
@@ -130,11 +129,11 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
 
   if (env_alt) {
     alt_home_ = std::stod(env_alt);
-    gzmsg << "[gazebo_gps_plugin] Home altitude is set to " << alt_home_ << ".\n";
+    gzmsg << "[gazebo_ros_gps_plugin] Home altitude is set to " << alt_home_ << ".\n";
   } else if (world_has_origin) {
     alt_home_ = world_altitude_;
-    gzmsg << "[gazebo_gps_plugin] Home altitude is set to " << alt_home_ << ".\n";
-  } else if(_sdf->HasElement("homeAltitude")) {
+    gzmsg << "[gazebo_ros_gps_plugin] Home altitude is set to " << alt_home_ << ".\n";
+  } else if (_sdf->HasElement("homeAltitude")) {
     getSdfParam<double>(_sdf, "homeAltitude", alt_home_, alt_home_);
   }
 
@@ -142,55 +141,49 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   if (_sdf->HasElement("gpsXYRandomWalk")) {
     getSdfParam<double>(_sdf, "gpsXYRandomWalk", gps_xy_random_walk_, kDefaultGpsXYRandomWalk);
   } else {
-    gzwarn << "[gazebo_gps_plugin] Using default random walk in XY plane: "
-           << kDefaultGpsXYRandomWalk << "\n";
+    gzwarn << "[gazebo_ros_gps_plugin] Using default random walk in XY plane: " << kDefaultGpsXYRandomWalk << "\n";
   }
 
   // get random walk in Z
   if (_sdf->HasElement("gpsZRandomWalk")) {
     getSdfParam<double>(_sdf, "gpsZRandomWalk", gps_z_random_walk_, kDefaultGpsZRandomWalk);
   } else {
-    gzwarn << "[gazebo_gps_plugin] Using default random walk in Z: "
-           << kDefaultGpsZRandomWalk << "\n";
+    gzwarn << "[gazebo_ros_gps_plugin] Using default random walk in Z: " << kDefaultGpsZRandomWalk << "\n";
   }
 
   // get position noise density in XY plane
   if (_sdf->HasElement("gpsXYNoiseDensity")) {
     getSdfParam<double>(_sdf, "gpsXYNoiseDensity", gps_xy_noise_density_, kDefaultGpsXYNoiseDensity);
   } else {
-    gzwarn << "[gazebo_gps_plugin] Using default position noise density in XY plane: "
-           << kDefaultGpsXYNoiseDensity << "\n";
+    gzwarn << "[gazebo_ros_gps_plugin] Using default position noise density in XY plane: " << kDefaultGpsXYNoiseDensity << "\n";
   }
 
   // get position noise density in Z
   if (_sdf->HasElement("gpsZNoiseDensity")) {
     getSdfParam<double>(_sdf, "gpsZNoiseDensity", gps_z_noise_density_, kDefaultGpsZNoiseDensity);
   } else {
-    gzwarn << "[gazebo_gps_plugin] Using default position noise density in Z: "
-           << kDefaultGpsZNoiseDensity << "\n";
+    gzwarn << "[gazebo_ros_gps_plugin] Using default position noise density in Z: " << kDefaultGpsZNoiseDensity << "\n";
   }
 
   // get velocity noise density in XY plane
   if (_sdf->HasElement("gpsVXYNoiseDensity")) {
     getSdfParam<double>(_sdf, "gpsVXYNoiseDensity", gps_vxy_noise_density_, kDefaultGpsVXYNoiseDensity);
   } else {
-    gzwarn << "[gazebo_gps_plugin] Using default velocity noise density in XY plane: "
-           << kDefaultGpsVXYNoiseDensity << "\n";
+    gzwarn << "[gazebo_ros_gps_plugin] Using default velocity noise density in XY plane: " << kDefaultGpsVXYNoiseDensity << "\n";
   }
 
   // get velocity noise density in Z
   if (_sdf->HasElement("gpsVZNoiseDensity")) {
     getSdfParam<double>(_sdf, "gpsVZNoiseDensity", gps_vz_noise_density_, kDefaultGpsVZNoiseDensity);
   } else {
-    gzwarn << "[gazebo_gps_plugin] Using default velocity noise density in Z: "
-           << kDefaultGpsVZNoiseDensity << "\n";
+    gzwarn << "[gazebo_ros_gps_plugin] Using default velocity noise density in Z: " << kDefaultGpsVZNoiseDensity << "\n";
   }
 
   namespace_.clear();
   if (_sdf->HasElement("robotNamespace")) {
     namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
   } else {
-    gzerr << "[gazebo_gps_plugin] Please specify a robotNamespace.\n";
+    gzerr << "[gazebo_ros_gps_plugin] Please specify a robotNamespace.\n";
   }
 
   // get update rate
@@ -198,8 +191,7 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
     getSdfParam<double>(_sdf, "update_rate", update_rate_, kDefaultUpdateRate);
   } else {
     update_rate_ = kDefaultUpdateRate;
-    gzwarn << "[gazebo_gps_plugin] Using default update rate of "
-           << kDefaultUpdateRate << "hz \n";
+    gzwarn << "[gazebo_ros_gps_plugin] Using default update rate of " << kDefaultUpdateRate << "hz \n";
   }
   parentSensor_->SetUpdateRate(update_rate_);
 
@@ -207,20 +199,45 @@ void GpsPlugin::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
   node_handle_->Init(namespace_);
 
   parentSensor_->SetActive(false);
-  updateSensorConnection_ = parentSensor_->ConnectUpdated(boost::bind(&GpsPlugin::OnSensorUpdate, this));
+  updateSensorConnection_ = parentSensor_->ConnectUpdated(boost::bind(&GazeboRosGpsPlugin::OnSensorUpdate, this));
   parentSensor_->SetActive(true);
 
   // Listen to the update event. This event is broadcast every simulation iteration.
-  updateWorldConnection_ = event::Events::ConnectWorldUpdateBegin(
-      boost::bind(&GpsPlugin::OnWorldUpdate, this, _1));
+  updateWorldConnection_ = event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosGpsPlugin::OnWorldUpdate, this, _1));
 
   gravity_W_ = world_->Gravity();
 
   gps_pub_ = node_handle_->Advertise<sensor_msgs::msgs::SITLGps>("~/" + model_name_ + "/link/" + gps_topic_, 10);
+
+  // Initiate ROS2 stuff
+  int    argc = 0;
+  char** argv = NULL;
+  if (!rclcpp::ok()) {
+    rclcpp::init(argc, argv);
+  }
+  ros_node_           = gazebo_ros::Node::Get();
+  activation_service_ = ros_node_->create_service<std_srvs::srv::SetBool>(
+      "/gazebo/gps_plugin/activate", std::bind(&GazeboRosGpsPlugin::activationCallback, this, std::placeholders::_1, std::placeholders::_2));
+  set_bad_gps_service_ = ros_node_->create_service<std_srvs::srv::SetBool>(
+      "/gazebo/gps_plugin/set_bad_gps", std::bind(&GazeboRosGpsPlugin::setBadGpsCallback, this, std::placeholders::_1, std::placeholders::_2));
+  activation_spoof_service_ = ros_node_->create_service<std_srvs::srv::SetBool>(
+      "/gazebo/gps_plugin/activate_spoof", std::bind(&GazeboRosGpsPlugin::activationGPSSpoofing, this, std::placeholders::_1, std::placeholders::_2));
+
+    gps_attack_.X() = 0;
+    gps_attack_.Y() = 0;
+
 }
 
-void GpsPlugin::OnWorldUpdate(const common::UpdateInfo& /*_info*/)
-{
+void GazeboRosGpsPlugin::OnWorldUpdate(const common::UpdateInfo& /*_info*/) {
+
+  {
+    std::scoped_lock lock(active_mutex_);
+    if (!active_) {
+      gzdbg << "GPS Switched OFF " << "\n";
+      return;
+    }
+  }
+
   // Store the pointer to the model.
   if (model_ == NULL)
 #if GAZEBO_MAJOR_VERSION >= 9
@@ -234,18 +251,18 @@ void GpsPlugin::OnWorldUpdate(const common::UpdateInfo& /*_info*/)
 #if GAZEBO_MAJOR_VERSION >= 9
   current_time = world_->SimTime();
 #else
-  current_time = world_->GetSimTime();
+  current_time                                = world_->GetSimTime();
 #endif
   double dt = (current_time - last_time_).Double();
 
 #if GAZEBO_MAJOR_VERSION >= 9
   ignition::math::Pose3d T_W_I = model_->WorldPose();
 #else
-  ignition::math::Pose3d T_W_I = ignitionFromGazeboMath(model_->GetWorldPose());
+  ignition::math::Pose3d   T_W_I              = ignitionFromGazeboMath(model_->GetWorldPose());
 #endif
   // Use the model world position for GPS
-  ignition::math::Vector3d& pos_W_I = T_W_I.Pos();
-  ignition::math::Quaterniond& att_W_I = T_W_I.Rot();
+  ignition::math::Vector3d&    pos_W_I = T_W_I.Pos();
+  [[maybe_unused]] ignition::math::Quaterniond& att_W_I = T_W_I.Rot();
 
   // Use the models' world position for GPS velocity.
 #if GAZEBO_MAJOR_VERSION >= 9
@@ -255,27 +272,26 @@ void GpsPlugin::OnWorldUpdate(const common::UpdateInfo& /*_info*/)
 #endif
 
   ignition::math::Vector3d velocity_current_W_xy = velocity_current_W;
-  velocity_current_W_xy.Z() = 0;
+  velocity_current_W_xy.Z()                      = 0;
 
   // update noise parameters if gps_noise_ is set
   if (gps_noise_) {
-    noise_gps_pos_.X() = gps_xy_noise_density_ * sqrt(dt) * randn_(rand_);
-    noise_gps_pos_.Y() = gps_xy_noise_density_ * sqrt(dt) * randn_(rand_);
-    noise_gps_pos_.Z() = gps_z_noise_density_ * sqrt(dt) * randn_(rand_);
-    noise_gps_vel_.X() = gps_vxy_noise_density_ * sqrt(dt) * randn_(rand_);
-    noise_gps_vel_.Y() = gps_vxy_noise_density_ * sqrt(dt) * randn_(rand_);
-    noise_gps_vel_.Z() = gps_vz_noise_density_ * sqrt(dt) * randn_(rand_);
+    noise_gps_pos_.X()   = gps_xy_noise_density_ * sqrt(dt) * randn_(rand_);
+    noise_gps_pos_.Y()   = gps_xy_noise_density_ * sqrt(dt) * randn_(rand_);
+    noise_gps_pos_.Z()   = gps_z_noise_density_ * sqrt(dt) * randn_(rand_);
+    noise_gps_vel_.X()   = gps_vxy_noise_density_ * sqrt(dt) * randn_(rand_);
+    noise_gps_vel_.Y()   = gps_vxy_noise_density_ * sqrt(dt) * randn_(rand_);
+    noise_gps_vel_.Z()   = gps_vz_noise_density_ * sqrt(dt) * randn_(rand_);
     random_walk_gps_.X() = gps_xy_random_walk_ * sqrt(dt) * randn_(rand_);
     random_walk_gps_.Y() = gps_xy_random_walk_ * sqrt(dt) * randn_(rand_);
     random_walk_gps_.Z() = gps_z_random_walk_ * sqrt(dt) * randn_(rand_);
-  }
-  else {
-    noise_gps_pos_.X() = 0.0;
-    noise_gps_pos_.Y() = 0.0;
-    noise_gps_pos_.Z() = 0.0;
-    noise_gps_vel_.X() = 0.0;
-    noise_gps_vel_.Y() = 0.0;
-    noise_gps_vel_.Z() = 0.0;
+  } else {
+    noise_gps_pos_.X()   = 0.0;
+    noise_gps_pos_.Y()   = 0.0;
+    noise_gps_pos_.Z()   = 0.0;
+    noise_gps_vel_.X()   = 0.0;
+    noise_gps_vel_.Y()   = 0.0;
+    noise_gps_vel_.Z()   = 0.0;
     random_walk_gps_.X() = 0.0;
     random_walk_gps_.Y() = 0.0;
     random_walk_gps_.Z() = 0.0;
@@ -286,17 +302,44 @@ void GpsPlugin::OnWorldUpdate(const common::UpdateInfo& /*_info*/)
   gps_bias_.Y() += random_walk_gps_.Y() * dt - gps_bias_.Y() / gps_corellation_time_;
   gps_bias_.Z() += random_walk_gps_.Z() * dt - gps_bias_.Z() / gps_corellation_time_;
 
-  // reproject position with noise into geographic coordinates
-  auto pos_with_noise = pos_W_I + noise_gps_pos_ + gps_bias_;
-  auto latlon = reproject(pos_with_noise, lat_home_, lon_home_, alt_home_);
 
+    
+
+{
+    std::scoped_lock lock(gps_spoof_mutex_);
+    if (spoofing_active_) {
+      //gzdbg << "GPS SPOOFING ACTIVE " << "\n";
+      gzdbg << "GPS SPOOFING Time: " << (current_time - spoof_start_time).Double() <<"\n";
+      // gps_attack_.X() = 1000;
+      // gps_attack_.Y() = 1000;
+
+      gps_attack_.X() = gps_attack_.X() + 0.005;
+      gps_attack_.Y() = gps_attack_.Y() + 0.005;
+    }
+}
+
+  // reproject position with noise into geographic coordinates
+  auto pos_with_noise = pos_W_I + noise_gps_pos_ + gps_bias_ + gps_attack_;
+  auto latlon         = reproject(pos_with_noise, lat_home_, lon_home_, alt_home_);
+  gzdbg << "Lat: " << latlon.first << "  Lon: " << latlon.second << "\n";
+
+  {
+    std::scoped_lock lock(gps_spoof_mutex_);
+    if ((spoofing_active_) && ((current_time - spoof_start_time).Double() > 32) )
+    {
+      
+      latlon.first = 0.427592;
+      latlon.second = 0.949146;
+      
+    }
+}
   // fill SITLGps msg
   sensor_msgs::msgs::SITLGps gps_msg;
 
   gps_msg.set_time_usec(current_time.Double() * 1e6);
   gps_msg.set_time_utc_usec((current_time.Double() + start_time_.Double()) * 1e6);
 
-  // @note Unfurtonately the Gazebo GpsSensor seems to provide bad readings,
+  // @note Unfurtonately the Gazeb o GpsSensor seems to provide bad readings,
   // starting to drift and leading to global position loss
   // gps_msg.set_latitude_deg(parentSensor_->Latitude().Degree());
   // gps_msg.set_longitude_deg(parentSensor_->Longitude().Degree());
@@ -306,8 +349,18 @@ void GpsPlugin::OnWorldUpdate(const common::UpdateInfo& /*_info*/)
   gps_msg.set_altitude(pos_W_I.Z() + alt_home_ - noise_gps_pos_.Z() + gps_bias_.Z());
 
   std_xy_ = 1.0;
-  std_z_ = 1.0;
-  gps_msg.set_eph(std_xy_);
+  std_z_  = 1.0;
+
+  {
+    std::scoped_lock lock(set_bad_gps_mutex_);
+    if(bad_gps_){
+      gps_msg.set_eph(2.5);
+    }
+    else{
+      gps_msg.set_eph(std_xy_);
+    }
+  }
+
   gps_msg.set_epv(std_z_);
 
   gps_msg.set_velocity_east(velocity_current_W.X() + noise_gps_vel_.Y());
@@ -327,8 +380,7 @@ void GpsPlugin::OnWorldUpdate(const common::UpdateInfo& /*_info*/)
   last_time_ = current_time;
 }
 
-void GpsPlugin::OnSensorUpdate()
-{
+void GazeboRosGpsPlugin::OnSensorUpdate() {
   // protect shared variables
   std::lock_guard<std::mutex> lock(data_mutex_);
 
@@ -350,13 +402,13 @@ void GpsPlugin::OnSensorUpdate()
         break;
       }
 
-      gps_msg = gps_delay_buffer_.front();
+      gps_msg                  = gps_delay_buffer_.front();
       double gps_current_delay = current_time_.Double() - gps_delay_buffer_.front().time_usec() / 1e6f;
 
       // remove data that is too old or if buffer size is too large
       if (gps_current_delay >= gps_delay_) {
         gps_delay_buffer_.pop();
-      // remove data if buffer too large
+        // remove data if buffer too large
       } else if (gps_delay_buffer_.size() > gps_buffer_size_max_) {
         gps_delay_buffer_.pop();
       } else {
@@ -368,4 +420,38 @@ void GpsPlugin::OnSensorUpdate()
     gps_pub_->Publish(gps_msg);
   }
 }
-} // namespace gazebo
+
+bool GazeboRosGpsPlugin::activationCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                            std::shared_ptr<std_srvs::srv::SetBool::Response>      response) {
+  std::scoped_lock lock(active_mutex_);
+  active_ = request->data;
+  RCLCPP_INFO(ros_node_->get_logger(), "[%s]: GPS plugin %s", ros_node_->get_name(), active_ ? "active" : "inactive");
+
+  response->message = "Success";
+  response->success = true;
+  return true;
+}
+
+bool GazeboRosGpsPlugin::setBadGpsCallback(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                            std::shared_ptr<std_srvs::srv::SetBool::Response>      response) {
+  std::scoped_lock lock(set_bad_gps_mutex_);
+  bad_gps_ = request->data;
+  RCLCPP_INFO(ros_node_->get_logger(), "[%s]: GPS quality is %s", ros_node_->get_name(), bad_gps_ ? "bad" : "good");
+
+  response->message = "Success";
+  response->success = true;
+  return true;
+}
+
+bool GazeboRosGpsPlugin::activationGPSSpoofing(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                            std::shared_ptr<std_srvs::srv::SetBool::Response>      response) {
+  std::scoped_lock lock(gps_spoof_mutex_);
+  spoofing_active_ = request->data;
+  RCLCPP_INFO(ros_node_->get_logger(), "[%s]: GPS Spoofing is %s", ros_node_->get_name(), spoofing_active_ ? "active" : "inactive");
+  spoof_start_time = last_time_;
+  response->message = "Success";
+  response->success = true;
+  return true;
+}
+
+}  // namespace gazebo


### PR DESCRIPTION
The GPS plugin has been added with ROS2 Services

1) Service to switch ON & OFF the GPS
2) Service to set the flag for Bad GPS signal

Developed by Fly4Future
Thes two services are added from
(https://github.com/fly4future/fog_gazebo_resources/blob/master/src/gazebo_ros_gps_plugin.cpp)

3) Service to simulate spoofed GPS
Developed for Abu Dhabi team use

The modified plugin wouldn't affect the default function of the GPS Plugin unless the ROS2 Service are called from the command line