### PR TITLE
DP-2268 gazebo mavlink plugin tcp client support

### DIFF
--- a/include/mavlink_interface.h
+++ b/include/mavlink_interface.h
@@ -165,6 +165,7 @@ public:
     inline void SetBaudrate(int baudrate) {baudrate_ = baudrate;}
     inline void SetSerialEnabled(bool serial_enabled) {serial_enabled_ = serial_enabled;}
     inline void SetUseTcp(bool use_tcp) {use_tcp_ = use_tcp;}
+    inline void SetTcpClientMode(bool tcp_client_mode) {tcp_client_mode_ = tcp_client_mode;}
     inline void SetDevice(std::string device) {device_ = device;}
     inline void SetEnableLockstep(bool enable_lockstep) {enable_lockstep_ = enable_lockstep;}
     inline void SetMavlinkAddr(std::string mavlink_addr) {mavlink_addr_str_ = mavlink_addr;}
@@ -186,6 +187,7 @@ private:
     void handle_message(mavlink_message_t *msg);
     void acceptConnections();
     void RegisterNewHILSensorInstance(int id);
+    bool tryConnect();
 
     // Serial interface
     void open_serial();
@@ -227,6 +229,7 @@ private:
     };
     struct pollfd fds_[N_FDS];
     bool use_tcp_{false};
+    bool tcp_client_mode_{false};
     bool close_conn_{false};
 
     in_addr_t mavlink_addr_;

--- a/models/ssrc_fog_x/ssrc_fog_x.sdf.jinja
+++ b/models/ssrc_fog_x/ssrc_fog_x.sdf.jinja
@@ -721,6 +721,7 @@
       <send_odometry>1</send_odometry>
       <enable_lockstep>{{ lockstep }}</enable_lockstep>
       <use_tcp>{{ use_tcp }}</use_tcp>
+      <tcp_client_mode>{{ tcp_client_mode }}</tcp_client_mode>
       <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
       <control_channels>
         <channel name='rotor1'>

--- a/scripts/jinja_gen.py
+++ b/scripts/jinja_gen.py
@@ -33,7 +33,8 @@ if __name__ == "__main__":
     parser.add_argument('--serial_baudrate', default=921600, help="Baudrate of Serial device for FMU")
     parser.add_argument('--qgc_addr', default="INADDR_ANY", help="IP address for QGC")
     parser.add_argument('--hil_mode', default=0, help="Enable HIL mode for HITL simulation")
-    parser.add_argument('--use_tcp', default=0, help="Use TCP instead of UDP for PX4 SITL")
+    parser.add_argument('--use_tcp', default=1, help="Use TCP instead of UDP for PX4 SITL")
+    parser.add_argument('--tcp_client_mode', default=1, help="Use TCP client mode instead of default server mode for PX4 SITL")
     parser.add_argument('--output-file', help="sdf output file")
     parser.add_argument('--stdout', action='store_true', default=False, help="dump to stdout instead of file")
     parser.add_argument('--mavlink_id', default=1, help="Mavlink system ID")
@@ -80,6 +81,7 @@ if __name__ == "__main__":
          'ros_version': ros_version, \
          'qgc_addr': args.qgc_addr, \
          'use_tcp': args.use_tcp, \
+         'tcp_client_mode': args.tcp_client_mode, \
          'vehicle_name': args.vehicle_name, \
          'lockstep': args.lockstep, \
          'gstudphost': args.gstudphost, \

--- a/src/gazebo_mavlink_interface.cpp
+++ b/src/gazebo_mavlink_interface.cpp
@@ -347,7 +347,15 @@ void GazeboMavlinkInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf
     use_tcp = _sdf->GetElement("use_tcp")->Get<bool>();
     mavlink_interface_->SetUseTcp(use_tcp);
   }
-  gzmsg << "Connecting to PX4 SITL using " << (serial_enabled ? "serial" : (use_tcp ? "TCP" : "UDP")) << "\n";
+
+  bool tcp_client_mode = false;
+  if (!serial_enabled && _sdf->HasElement("tcp_client_mode"))
+  {
+    tcp_client_mode = _sdf->GetElement("tcp_client_mode")->Get<bool>();
+    mavlink_interface_->SetTcpClientMode(tcp_client_mode);
+  }
+  gzmsg << "Connecting to PX4 SITL using " << (serial_enabled ? "serial" :
+    (use_tcp ? (tcp_client_mode ? "TCP (client mode)" : "TCP (server mode)") : "UDP")) << "\n";
 
   if (!hil_mode_ && _sdf->HasElement("enable_lockstep"))
   {


### PR DESCRIPTION
Add support for connecting PX4_SITL as TCP client. This requires that simulator module in PX4_SITL is started with '-s' flag to start TCP server.
ssrc_fog_x sdf and jinja_gen script has support for TCP client mode connection. 
To enable it, call jinja_gen script with "--use_tcp=1" and "--tcp_client_mode=1" flags.
